### PR TITLE
fix: declare httpClient property to eliminate PHP deprecation warning

### DIFF
--- a/src/Rest/Client.php
+++ b/src/Rest/Client.php
@@ -10,6 +10,8 @@ class Client
 {
     public const THOTH_EXPORT_BASE_URI = 'https://export.thoth.pub/';
 
+    private HttpClient $httpClient;
+
     public function __construct(array $httpConfig = [])
     {
         if (!isset($httpConfig['base_uri'])) {


### PR DESCRIPTION
Add explicit type declaration for the $httpClient property to prevent the "Creation of dynamic property" deprecation warning in PHP 8.2+.

This property was previously assigned without declaration in the constructor, which triggers a deprecation warning. Declaring it as a typed property resolves this issue.

Resolves #16 